### PR TITLE
510-bug fixes

### DIFF
--- a/src/Components/Default/ProductCard.tsx
+++ b/src/Components/Default/ProductCard.tsx
@@ -86,7 +86,7 @@ function ProductCard({
                                                 width: '100%',
                                                 height: '100%',
                                                 paddingLeft: 2,
-                                                backgroundColor: 'rgba(255, 255, 255, 0.4)',
+                                                backgroundColor: 'rgba(255, 255, 255, 0.9)',
                                                 backdropFilter: 'blur(6px)',
                                             }}
                                             justifyContent="space-evenly"

--- a/src/Components/Default/ProductDetails.tsx
+++ b/src/Components/Default/ProductDetails.tsx
@@ -57,7 +57,6 @@ function ProductDetails() {
                                     <CardMedia
                                         component="img"
                                         alt="product image"
-                                        height="350"
                                         image={`${window.location.protocol}//${window.location.hostname}:8000/media/${image}`}
                                     />
                                 </CardActionArea>

--- a/src/Components/Default/Profilepage/OrderPage.tsx
+++ b/src/Components/Default/Profilepage/OrderPage.tsx
@@ -70,7 +70,7 @@ function OrderPage() {
                                         <Box
                                             sx={{
                                                 height: 'inherit',
-                                                backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                                                backgroundColor: 'rgba(255, 255, 255, 0.9)',
                                                 backdropFilter: 'blur(3px)',
                                             }}
                                         >

--- a/src/Components/Default/SimilarProductCard.tsx
+++ b/src/Components/Default/SimilarProductCard.tsx
@@ -37,7 +37,7 @@ function SimilarProductCard({ product }: SimilarProduct) {
                 <CardMedia
                     component={Box}
                     sx={{ alt: 'kuva' }}
-                    height={100}
+                    height={200}
                     image={`${window.location.protocol}//${window.location.hostname}:8000/media/${product?.pictures[0]?.picture_address}`}
                 />
                 <CardHeader
@@ -49,7 +49,7 @@ function SimilarProductCard({ product }: SimilarProduct) {
                     }
                 />
             </CardActionArea>
-            <CardActions>
+            {/* <CardActions>
                 <Grid container direction="row" justifyContent="space-evenly" alignItems="center">
                     <Grid item>
                         <AddToCartButton
@@ -76,7 +76,7 @@ function SimilarProductCard({ product }: SimilarProduct) {
                         </Tooltip>
                     </Grid>
                 </Grid>
-            </CardActions>
+            </CardActions> */}
         </Card>
     );
 }


### PR DESCRIPTION
**Description**

bug fix:
- user profile -> active and past orders page showed products storage amount instead of order amount
- if similar products doesn't have image it crashes 
- product details page crashes if product doesn't have image

features:
- removed add to cart and info buttons from similar products card
- product details page shows whole image instead of cropped image

**Trello card**
[Trello Card #510](https://trello.com/c/r21fT6If)
