### PR TITLE
added min length to password reset

### DIFF
--- a/src/Components/Default/ResetPassword/ResetPassword.tsx
+++ b/src/Components/Default/ResetPassword/ResetPassword.tsx
@@ -59,6 +59,7 @@ function ResetPassword() {
                         <OutlinedInput
                             {...register('new_password', {
                                 required: true,
+                                minLength: { value: 16, message: 'Salasanan on oltava vähintään 16 merkkiä' },
                                 maxLength: 255,
                             })}
                             id="outlined-adornment-password"


### PR DESCRIPTION
**Description**

password reset now has min length of 16 characters