### PR TITLE
Bike add package fix

### DIFF
--- a/src/Router/actions.jsx
+++ b/src/Router/actions.jsx
@@ -987,7 +987,6 @@ const updateBikesStockPacketOnlyFlag = async () => {
         const amountNeeded = bikeAmounts.find((item) => item.bikeId === uniqueBikeId)?.amount ?? 0;
         // bikes with packet_only === true
         for (let i = 0; i < amountNeeded - 1; i++) {
-            console.log(i);
             const newBike = {
                 ...bikesWithuniqueBikeId[i],
                 bike: bikesWithuniqueBikeId[i].bike.id,


### PR DESCRIPTION
**Description**

fixed a bug that made bike package creation look like it didn't went through. reason was that for loop tried to access index that was outside of bikesWithuniqueBikeId array